### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.4
+
+# Install dependencies
+RUN pip install requests python-dateutil responses
+
+# Install SLAMon Python Agent
+RUN mkdir workspace
+ADD . /workspace
+WORKDIR /workspace
+RUN pip install .
+
+CMD ["sh", "-c", "slamon-agent -u ${AFM} -l ${HANDLERS} ${EXTRA_FLAGS}"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,13 @@
 FROM python:3.4
 
 # Run as non-root, eventually
-RUN groupadd -r slamon && useradd -r -d /workspace -m -g slamon slamon 
+RUN groupadd -r slamon && useradd -r -g slamon slamon
 
 # Install SLAMon Python Agent
 ADD . /workspace
 WORKDIR /workspace
 RUN pip install .
-RUN chown -R slamon:slamon /workspace
-RUN rm -rf /workspace/*
+RUN rm -rf /workspace
 
 # Change to a non-root user
 USER slamon

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,14 +3,12 @@ FROM python:3.4
 # Run as non-root, eventually
 RUN groupadd -r slamon && useradd -r -d /workspace -m -g slamon slamon 
 
-# Install dependencies
-RUN pip install requests python-dateutil responses
-
 # Install SLAMon Python Agent
 ADD . /workspace
 WORKDIR /workspace
 RUN pip install .
 RUN chown -R slamon:slamon /workspace
+RUN rm -rf /workspace/*
 
 # Change to a non-root user
 USER slamon

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,18 @@
 FROM python:3.4
 
+# Run as non-root, eventually
+RUN groupadd -r slamon && useradd -r -d /workspace -m -g slamon slamon 
+
 # Install dependencies
 RUN pip install requests python-dateutil responses
 
 # Install SLAMon Python Agent
-RUN mkdir workspace
 ADD . /workspace
 WORKDIR /workspace
 RUN pip install .
+RUN chown -R slamon:slamon /workspace
+
+# Change to a non-root user
+USER slamon
 
 CMD ["sh", "-c", "slamon-agent -u ${AFM} -l ${HANDLERS} ${EXTRA_FLAGS}"]

--- a/README.md
+++ b/README.md
@@ -104,6 +104,38 @@ def wait_task_handler(input_params):
    return {'time': timeout}
 ```
 
+Docker images
+-------------
+
+Pre-existing images are built from `master` and `dev` branches:
+`slamon/agent:stable` and `slamon/agent:latest` respectively, and also
+from GitHub tags as `slamon/agent:<tag>`.
+
+### Using the images
+
+The image offers an entrypoint that requires two environment values to
+be defined: `AFM` and `HANDLERS` (Note: The handlers are not generally
+required but since the agent is useless without them, it is required
+here). There also exists an `EXTRA_FLAGS` environment variable that can
+be used to add f.ex. verbosity flags.
+
+If you want to override how `slamon-agent` is started, you need to
+redefine the `CMD` verb.
+
+#### With Docker Compose
+
+The following snippet can be used:
+
+```yml
+agent:
+  image: slamon/agent:stable
+  environment:
+    AFM: "http://slamon-afm"
+    HANDLERS: "slamon_agent.handlers"
+    EXTRA_FLAGS: "-v"
+```
+
+
 [license]: https://img.shields.io/:license-Apache%20License%20v2.0-blue.svg
 [ci_status]: https://travis-ci.org/SLAMon/slamon-python-agent.svg?branch=master
 [coveralls]: https://coveralls.io/repos/SLAMon/slamon-python-agent/badge.svg?branch=master&service=github


### PR DESCRIPTION
This adds a Dockerfile that can be used to build image that can run SLAMon Python Agent. It is also recommended to create a Docker Hub account (Organization) to where an Automated Build can be created!

Example: https://hub.docker.com/r/stealthyloner/slamon-agent/ (One of the tags reports an error since it tries to build from master)
